### PR TITLE
fix(module): renamed module reference to project name

### DIFF
--- a/branch/handler.go
+++ b/branch/handler.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/go-git/go-git/v5"
-	"github.com/leonsteinhaeuser/git-tag-identifier/release"
+	"github.com/leonsteinhaeuser/git-tag-bump/release"
 )
 
 var (

--- a/branch/handler_test.go
+++ b/branch/handler_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/storage/memory"
-	"github.com/leonsteinhaeuser/git-tag-identifier/release"
+	"github.com/leonsteinhaeuser/git-tag-bump/release"
 )
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/leonsteinhaeuser/git-tag-identifier
+module github.com/leonsteinhaeuser/git-tag-bump
 
 go 1.19
 

--- a/main.go
+++ b/main.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/go-git/go-git/v5"
 	gconfig "github.com/go-git/go-git/v5/config"
-	"github.com/leonsteinhaeuser/git-tag-identifier/branch"
-	"github.com/leonsteinhaeuser/git-tag-identifier/release"
+	"github.com/leonsteinhaeuser/git-tag-bump/branch"
+	"github.com/leonsteinhaeuser/git-tag-bump/release"
 	"gopkg.in/yaml.v3"
 )
 


### PR DESCRIPTION
When renaming the project, we forgot to rename the module reference as well, which caused the go.mod file to panic with `Error parsing go.mod`

See: #8 