### PR TITLE
feat: define "create" tag git actor

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ A simple tool to bump git tags (semver). It can be used to bump the patch, minor
 | `--pre-release-prefix` | `string` | false    | `rc` | The prefix of the pre-release tag. Example: When defining the following tag `v1.0.0-rc.1`, `rc` would be the prefix and the number after it the format ***semver***. |
 | `--repo-path`   | `string` | false    | `.` | The path to the git repository. If not defined, the current working directory will be used. |
 | `--create` | `bool` | false | `false` | Whether to create and push the tag if it does not exist. |
+| `--actor-name` | `string` | false | `` | The name of the actor used to create the tag. Only used if `--create` is set. |
+| `--actor-email` | `string` | false | `` | The mail of the actor used to create the tag. Only used if `--create` is set. |
 | `--branch-name` | `string` | false | `` | The name of the branch to use. |
 | `--v-prefix`   | `bool` | false    | `true` | Whether to prefix the tag with `v`. Example: `v1.0.0` instead of `1.0.0`. |
 

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/go-git/go-git/v5"
 	gconfig "github.com/go-git/go-git/v5/config"
+	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/leonsteinhaeuser/git-tag-bump/branch"
 	"github.com/leonsteinhaeuser/git-tag-bump/release"
 	"gopkg.in/yaml.v3"
@@ -23,6 +24,14 @@ var (
 	createTag        = flag.Bool("create", false, "Whether to create a tag in the repository and push it to the remote")
 	branchName       = flag.String("branch-name", "", "Name of the branch to check")
 	vPrefix          = flag.Bool("v-prefix", true, "Whether to prefix the tag with a 'v'. E.g. v1.0.0 instead of 1.0.0")
+
+	actorName = flag.String("actor-name", "", "The name of the actor used to create the tag. Only used if --create is set.")
+	actorMail = flag.String("actor-mail", "", "The mail of the actor used to create the tag. Only used if --create is set.")
+
+	actor = &object.Signature{
+		Name:  *actorName,
+		Email: *actorMail,
+	}
 
 	//go:embed config.yaml
 	configBts []byte
@@ -96,6 +105,12 @@ func main() {
 		pmbrfc, err := repo.CreateTag(newTag, rfc.Hash(), &git.CreateTagOptions{
 			//Tagger:  nil,
 			Message: newTag,
+			Tagger: func() *object.Signature {
+				if actor.Name == "" || actor.Email == "" {
+					return nil
+				}
+				return actor
+			}(),
 		})
 		if err != nil {
 			panic(err)

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	_ "embed"
 	"flag"
 	"fmt"
+	"time"
 
 	"github.com/go-git/go-git/v5"
 	gconfig "github.com/go-git/go-git/v5/config"
@@ -31,6 +32,7 @@ var (
 	actor = &object.Signature{
 		Name:  *actorName,
 		Email: *actorMail,
+		When:  time.Now(),
 	}
 
 	//go:embed config.yaml


### PR DESCRIPTION
When running workflows with `--create`, the Git owner is not specified, which causes the creation to fail. To solve this problem, we added two flags to define the `actor` for creating the tag.

See: #8 